### PR TITLE
JSXify the header

### DIFF
--- a/www/static/js/component/header.js
+++ b/www/static/js/component/header.js
@@ -4,7 +4,7 @@ const React = require('react');
 const DOM = React.DOM;
 
 const domToReact = require('../lib/domtoreact');
-const ColumnHeadingsNav = React.createFactory(require('./column-heading-nav'));
+const ColumnHeadingsNav = require('./column-heading-nav');
 
 module.exports = React.createClass({
   displayName: 'HeaderView',
@@ -19,15 +19,13 @@ module.exports = React.createClass({
 
   render() {
     if (this.props.columns) {
-      return DOM.header({ className: 'app-header' },
-        this.props.title,
-        ColumnHeadingsNav({ columns: this.props.columns, swiper: this.props.swiper })
-      );
+      return <header className="app-header">
+        {this.props.title}
+        <ColumnHeadingsNav columns={this.props.columns} swiper={this.props.swiper} />
+      </header>;
     }
     else {
-      return DOM.header({ className: 'app-header' },
-        this.props.title
-      );
+      return <header className="app-header">{this.props.title}</header>;
     }
   }
 });


### PR DESCRIPTION
Everyone happy with this? We can avoid manually creating factories this way and I actually think it's more readable. 6to5 has native support, so we don't need to change anything wrt the build chain.